### PR TITLE
Return the task id when adding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* adding a task now returns its UUID, previously nothign was returned
+
 ## 0.0.5 - 2023-11-06
 
 * Upgraded dependencies, now this library requires Python 3.9 (previously was 3.8)

--- a/postgrestq/task_queue.py
+++ b/postgrestq/task_queue.py
@@ -116,7 +116,7 @@ class TaskQueue:
 
     def add(
         self, task: Dict[str, Any], lease_timeout: float, ttl: int = 3
-    ) -> None:
+    ) -> str:
         """Add a task to the task queue.
 
         Parameters
@@ -129,6 +129,10 @@ class TaskQueue:
             Number of (re-)tries, including the initial one, in case the
             job dies.
 
+        Returns
+        -------
+        task_id :
+            The random UUID that was generated for this task
         """
         # make sure the timeout is an actual number, otherwise we'll run
         # into problems later when we calculate the actual deadline
@@ -156,6 +160,7 @@ class TaskQueue:
                 (id_, self._queue_name, serialized_task, ttl, lease_timeout),
             )
             self.conn.commit()
+        return id_
 
     def get(self) -> Tuple[Optional[Dict[str, Any]], Optional[UUID]]:
         """Get a task from the task queue (non-blocking).

--- a/tests/test_task_queue.py
+++ b/tests/test_task_queue.py
@@ -34,9 +34,11 @@ def task_queue():
 def test_add(task_queue: TaskQueue):
     # add two tasks and get them back in correct order
     TASKS = [{"foo": 1}, {"bar": 2}]
+    task_ids = set()
     for task in TASKS:
-        task_queue.add(task, LEASE_TIMEOUT)
-
+        tid = task_queue.add(task, LEASE_TIMEOUT)
+        task_ids.add(tid)
+    assert len(task_ids) == 2
     task, _ = task_queue.get()
     assert task == TASKS[0]
     task, _ = task_queue.get()


### PR DESCRIPTION
This makes the `add` method return the UUID of the task just created